### PR TITLE
fix: 移除不必要的 moduleId

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -255,7 +255,7 @@ module.exports = function (content) {
   if (script) {
     // for mp js
     // 需要解析组件的 components 给 wxml 生成用
-    script = compileMPScript.call(this, script, mpOptions, moduleId)
+    script = compileMPScript.call(this, script, mpOptions, hasScoped && moduleId)
 
     if (options.esModule) {
       output += script.src


### PR DESCRIPTION
fix https://github.com/Meituan-Dianping/mpvue/issues/312 ，style 没有设置 scoped 属性的话，template 的 moduleId 应该就没有必要存在了