### PR TITLE
生成slot文件中，使用fs.writeFile代替emitFile，修复不能热更的bug

### DIFF
--- a/lib/mp-compiler/index.js
+++ b/lib/mp-compiler/index.js
@@ -19,25 +19,30 @@ const {
   getSlots,
   htmlBeautify,
   getBabelrc,
-  getPageSrc
+  getPageSrc,
+  debounce
 } = require('./util')
 
-function createSlotsWxml (emitFile, slots, importCode) {
+const writeFile = debounce((outputPath, content) => {
+  fs.writeFile(outputPath, htmlBeautify(content))
+}, 100)
+
+function createSlotsWxml (emitFile, slots, importCode, outputPath) {
   cacheSlots(slots, importCode)
   const content = getSlots()
   if (content.trim()) {
-    emitFile('components/slots.wxml', htmlBeautify(content))
+    writeFile(path.resolve(outputPath, 'components/slots.wxml'), content)
   }
 }
 
 // 调用 compiler 生成 wxml
-function genComponentWxml (compiled, options, emitFile, emitError, emitWarning) {
+function genComponentWxml (compiled, options, emitFile, emitError, emitWarning, outputPath) {
   options.components['slots'] = { src: 'slots', name: 'slots' }
   const { code: wxmlCodeStr, compiled: cp, slots, importCode } = compiler.compileToWxml(compiled, options)
   const { mpErrors, mpTips } = cp
 
   // 缓存 slots，延迟编译
-  createSlotsWxml(emitFile, slots, importCode)
+  createSlotsWxml(emitFile, slots, importCode, outputPath)
 
   if (mpErrors && mpErrors.length) {
     emitError(
@@ -53,7 +58,7 @@ function genComponentWxml (compiled, options, emitFile, emitError, emitWarning) 
   return htmlBeautify(wxmlCodeStr)
 }
 
-function createWxml (emitWarning, emitError, emitFile, resourcePath, rootComponent, compiled, html) {
+function createWxml (emitWarning, emitError, emitFile, resourcePath, rootComponent, compiled, html, outputPath) {
   const { pageType, moduleId, components, src } = getFileInfo(resourcePath) || {}
 
   // 这儿一个黑魔法，和 webpack 约定的规范写法有点偏差！
@@ -80,7 +85,7 @@ function createWxml (emitWarning, emitError, emitFile, resourcePath, rootCompone
     // }
     const name = getCompNameBySrc(resourcePath)
     const options = { components, pageType, name, moduleId }
-    wxmlContent = genComponentWxml(compiled, options, emitFile, emitError, emitWarning)
+    wxmlContent = genComponentWxml(compiled, options, emitFile, emitError, emitWarning, outputPath)
     wxmlSrc = `components/${name}`
   }
 
@@ -89,7 +94,7 @@ function createWxml (emitWarning, emitError, emitFile, resourcePath, rootCompone
 
 // 编译出 wxml
 function compileWxml (compiled, html) {
-  return createWxml(this.emitWarning, this.emitError, this.emitFile, this.resourcePath, null, compiled, html)
+  return createWxml(this.emitWarning, this.emitError, this.emitFile, this.resourcePath, null, compiled, html, this.options.output.path)
 }
 
 // 针对 .vue 单文件的脚本逻辑的处理

--- a/lib/mp-compiler/index.js
+++ b/lib/mp-compiler/index.js
@@ -23,15 +23,25 @@ const {
   debounce
 } = require('./util')
 
-const writeFile = debounce((outputPath, content) => {
-  fs.writeFile(outputPath, htmlBeautify(content))
+const writeFile = debounce((dist, subDist, filename, content) => {
+  const { existsSync, mkdirSync } = fs
+  if (!existsSync(dist)) {
+    mkdirSync(dist)
+  }
+  if (!existsSync(subDist)) {
+    mkdirSync(subDist)
+  }
+  fs.writeFile(filename, htmlBeautify(content))
 }, 100)
 
 function createSlotsWxml (emitFile, slots, importCode, outputPath) {
   cacheSlots(slots, importCode)
   const content = getSlots()
   if (content.trim()) {
-    writeFile(path.resolve(outputPath, 'components/slots.wxml'), content)
+    const { resolve } = path
+    const subDist = resolve(outputPath, 'components')
+    const filename = resolve(subDist, 'slots.wxml')
+    writeFile(outputPath, subDist, filename, content)
   }
 }
 

--- a/lib/mp-compiler/index.js
+++ b/lib/mp-compiler/index.js
@@ -4,6 +4,7 @@ const compiler = require('mpvue-template-compiler')
 const babel = require('babel-core')
 const path = require('path')
 const fs = require('fs')
+const mkdirp = require('mkdirp')
 
 const { parseConfig, parseComponentsDeps } = require('./parse')
 const { parseComponentsDeps: parseComponentsDepsTs } = require('./parse-ts')
@@ -23,15 +24,11 @@ const {
   debounce
 } = require('./util')
 
-const writeFile = debounce((dist, subDist, filename, content) => {
-  const { existsSync, mkdirSync } = fs
-  if (!existsSync(dist)) {
-    mkdirSync(dist)
-  }
-  if (!existsSync(subDist)) {
-    mkdirSync(subDist)
-  }
-  fs.writeFile(filename, htmlBeautify(content))
+const writeFile = debounce((dir, filepath, content) => {
+  mkdirp(dir, err => {
+    if (err) console.error(err)
+    fs.writeFile(filepath, htmlBeautify(content))
+  })
 }, 100)
 
 function createSlotsWxml (emitFile, slots, importCode, outputPath) {
@@ -39,9 +36,9 @@ function createSlotsWxml (emitFile, slots, importCode, outputPath) {
   const content = getSlots()
   if (content.trim()) {
     const { resolve } = path
-    const subDist = resolve(outputPath, 'components')
-    const filename = resolve(subDist, 'slots.wxml')
-    writeFile(outputPath, subDist, filename, content)
+    const dir = resolve(outputPath, 'components')
+    const filepath = resolve(dir, 'slots.wxml')
+    writeFile(dir, filepath, content)
   }
 }
 

--- a/lib/mp-compiler/util.js
+++ b/lib/mp-compiler/util.js
@@ -119,6 +119,16 @@ function getPathPrefix (src) {
   return `${'../'.repeat(length)}`
 }
 
+function debounce (fn, delay) {
+  let timer = null
+  return function (...args) {
+    clearTimeout(timer)
+    timer = setTimeout(() => {
+      fn.apply(this, args)
+    }, delay)
+  }
+}
+
 const defaultStylePart = {
   type: 'style',
   content: '\n',
@@ -146,5 +156,6 @@ module.exports = {
   htmlBeautify,
   getBabelrc,
   getPathPrefix,
-  getPageSrc
+  getPageSrc,
+  debounce
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mpvue-loader",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "mpvue single-file component loader for Webpack",
   "main": "index.js",
   "repository": {
@@ -67,7 +67,7 @@
   },
   "peerDependencies": {
     "css-loader": "*",
-    "mpvue-template-compiler": "^1.0.7"
+    "mpvue-template-compiler": "^1.0.9"
   },
   "devDependencies": {
     "babel-core": "^6.25.0",
@@ -90,7 +90,7 @@
     "marked": "^0.3.6",
     "memory-fs": "^0.4.1",
     "mkdirp": "^0.5.1",
-    "mpvue-template-compiler": "^1.0.7",
+    "mpvue-template-compiler": "^1.0.9",
     "mocha": "^3.4.2",
     "node-libs-browser": "^2.0.0",
     "normalize-newline": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mpvue-loader",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "mpvue single-file component loader for Webpack",
   "main": "index.js",
   "repository": {
@@ -67,7 +67,7 @@
   },
   "peerDependencies": {
     "css-loader": "*",
-    "mpvue-template-compiler": "^1.0.9"
+    "mpvue-template-compiler": "^1.0.10"
   },
   "devDependencies": {
     "babel-core": "^6.25.0",
@@ -90,7 +90,7 @@
     "marked": "^0.3.6",
     "memory-fs": "^0.4.1",
     "mkdirp": "^0.5.1",
-    "mpvue-template-compiler": "^1.0.9",
+    "mpvue-template-compiler": "^1.0.10",
     "mocha": "^3.4.2",
     "node-libs-browser": "^2.0.0",
     "normalize-newline": "^3.0.0",


### PR DESCRIPTION
现在是用setTimeout延迟emitFile的执行，在`npm run dev`的时候能正确输出文件，但是无法热更，可能是webpack执行完毕了，但还没跑的emitFile被阻止了。所以这里改成使用fs.writeFile