### PR TITLE
fix: 修复 new Vue 解析错误

### DIFF
--- a/lib/mp-compiler/parse.js
+++ b/lib/mp-compiler/parse.js
@@ -55,6 +55,11 @@ const configVisitor = {
     }
 
     const arg = path.node.arguments[0]
+
+    if (!arg) {
+      return
+    }
+
     const v = arg.type === 'Identifier' ? importsMap[arg.name] : importsMap['App']
     metadata.rootComponent = v || importsMap['index'] || importsMap['main']
   }


### PR DESCRIPTION
`vue` 中 `eventBus` 的典型用法是

``` js
import Vue from 'vue'

const bus = new Vue()

export default bus
```

目前对 `new Vue` 的解析配置会导致 `eventBus` 不可用，错误如下

```
TypeError: unknown: Cannot read property 'type' of undefined
```