### PR TITLE
feat: 支持间接引用组件

### DIFF
--- a/lib/mp-compiler/index.js
+++ b/lib/mp-compiler/index.js
@@ -252,7 +252,7 @@ function resolveRealComSrc (realSrc, m, resolveFn) {
       const result = babel.transform(scriptContent)
       const { importsMap } = getImportsMap(result.metadata)
       const { exportsMap } = getExportsMap(result.metadata)
-      const source = importsMap[exportsMap[m]]
+      const source = importsMap[exportsMap[m] || m]
       resolveFn(path.dirname(realSrc), source, (err, realComSrc) => {
         if (err) return reject(err)
         resolve(resolveRealComSrc(realComSrc, exportsMap[m], resolveFn))

--- a/lib/mp-compiler/index.js
+++ b/lib/mp-compiler/index.js
@@ -21,7 +21,8 @@ const {
   htmlBeautify,
   getBabelrc,
   getPageSrc,
-  getImportsMap
+  getImportsMap,
+  getExportsMap
 } = require('./util')
 
 let slotsHookAdded = false
@@ -243,29 +244,36 @@ function compileMP (content, mpOptioins) {
   return content
 }
 
+function resolveRealComSrc (realSrc, m, resolveFn) {
+  return new Promise((resolve, reject) => {
+    const isScript = /\.js$/.test(realSrc)
+    if (isScript) {
+      const scriptContent = fs.readFileSync(realSrc).toString()
+      const result = babel.transform(scriptContent)
+      const { importsMap } = getImportsMap(result.metadata)
+      const { exportsMap } = getExportsMap(result.metadata)
+      const source = importsMap[exportsMap[m]]
+      resolveFn(path.dirname(realSrc), source, (err, realComSrc) => {
+        if (err) return reject(err)
+        resolve(resolveRealComSrc(realComSrc, exportsMap[m], resolveFn))
+      })
+    } else {
+      resolve(realSrc)
+    }
+  })
+}
+
 function resolveSrc (originComponents, components, resolveFn, context) {
   return Promise.all(Object.keys(originComponents).map(k => {
     return new Promise((resolve, reject) => {
-      resolveFn(context, originComponents[k], (err, realSrc) => {
+      resolveFn(context, originComponents[k].src, (err, realSrc) => {
         if (err) return reject(err)
         const com = covertCCVar(k)
-        const isScript = /\.js$/.test(realSrc)
-        if (isScript) {
-          const scriptContent = fs.readFileSync(realSrc).toString()
-          const result = babel.transform(scriptContent)
-          const { importsMap } = getImportsMap(result.metadata)
-          const source = importsMap[k]
-          resolveFn(path.dirname(realSrc), source, (err, realComSrc) => {
-            if (err) return reject(err)
-            const comName = getCompNameBySrc(realComSrc)
-            components[com] = { src: comName, name: comName }
-            resolve()
-          })
-        } else {
-          const comName = getCompNameBySrc(realSrc)
+        resolveRealComSrc(realSrc, originComponents[k].module, resolveFn).then(realComSrc => {
+          const comName = getCompNameBySrc(realComSrc)
           components[com] = { src: comName, name: comName }
           resolve()
-        }
+        })
       })
     })
   }))

--- a/lib/mp-compiler/index.js
+++ b/lib/mp-compiler/index.js
@@ -255,7 +255,7 @@ function resolveRealComSrc (realSrc, m, resolveFn) {
       const source = importsMap[exportsMap[m] || m]
       resolveFn(path.dirname(realSrc), source, (err, realComSrc) => {
         if (err) return reject(err)
-        resolve(resolveRealComSrc(realComSrc, exportsMap[m], resolveFn))
+        resolveRealComSrc(realComSrc, exportsMap[m], resolveFn).then(resolve).catch(reject)
       })
     } else {
       resolve(realSrc)
@@ -273,7 +273,7 @@ function resolveSrc (originComponents, components, resolveFn, context) {
           const comName = getCompNameBySrc(realComSrc)
           components[com] = { src: comName, name: comName }
           resolve()
-        })
+        }).catch(reject)
       })
     })
   }))

--- a/lib/mp-compiler/index.js
+++ b/lib/mp-compiler/index.js
@@ -20,7 +20,8 @@ const {
   getSlots,
   htmlBeautify,
   getBabelrc,
-  getPageSrc
+  getPageSrc,
+  getImportsMap
 } = require('./util')
 
 let slotsHookAdded = false
@@ -248,12 +249,23 @@ function resolveSrc (originComponents, components, resolveFn, context) {
       resolveFn(context, originComponents[k], (err, realSrc) => {
         if (err) return reject(err)
         const com = covertCCVar(k)
-        const realComSrc = /\.js$/.test(realSrc)
-          ? path.join(path.dirname(realSrc), `${com}.vue`)
-          : realSrc
-        const comName = getCompNameBySrc(realComSrc)
-        components[com] = { src: comName, name: comName }
-        resolve()
+        const isScript = /\.js$/.test(realSrc)
+        if (isScript) {
+          const scriptContent = fs.readFileSync(realSrc).toString()
+          const result = babel.transform(scriptContent)
+          const { importsMap } = getImportsMap(result.metadata)
+          const source = importsMap[k]
+          resolveFn(path.dirname(realSrc), source, (err, realComSrc) => {
+            if (err) return reject(err)
+            const comName = getCompNameBySrc(realComSrc)
+            components[com] = { src: comName, name: comName }
+            resolve()
+          })
+        } else {
+          const comName = getCompNameBySrc(realSrc)
+          components[com] = { src: comName, name: comName }
+          resolve()
+        }
       })
     })
   }))

--- a/lib/mp-compiler/index.js
+++ b/lib/mp-compiler/index.js
@@ -248,7 +248,10 @@ function resolveSrc (originComponents, components, resolveFn, context) {
       resolveFn(context, originComponents[k], (err, realSrc) => {
         if (err) return reject(err)
         const com = covertCCVar(k)
-        const comName = getCompNameBySrc(realSrc)
+        const realComSrc = /\.js$/.test(realSrc)
+          ? path.join(path.dirname(realSrc), `${com}.vue`)
+          : realSrc
+        const comName = getCompNameBySrc(realComSrc)
         components[com] = { src: comName, name: comName }
         resolve()
       })

--- a/lib/mp-compiler/parse.js
+++ b/lib/mp-compiler/parse.js
@@ -2,23 +2,7 @@
 
 const generate = require('babel-generator').default
 const babelon = require('babelon')
-
-function getImportsMap (metadata) {
-  let { importsMap } = metadata
-  const { imports } = metadata.modules
-
-  if (!importsMap) {
-    importsMap = {}
-    imports.forEach(m => {
-      m.specifiers.forEach(v => {
-        importsMap[v.local] = m.source
-      })
-    })
-    metadata.importsMap = importsMap
-  }
-
-  return metadata
-}
+const { getImportsMap } = require('./util')
 
 // 解析 config
 const traverseConfigVisitor = {

--- a/lib/mp-compiler/parse.js
+++ b/lib/mp-compiler/parse.js
@@ -70,7 +70,10 @@ const traverseComponentsVisitor = {
       const k = p.key.name || p.key.value
       const v = p.value.name || p.value.value
 
-      components[k] = importsMap[v]
+      components[k] = {
+        src: importsMap[v],
+        module: v
+      }
     })
 
     metadata.components = components

--- a/lib/mp-compiler/parse.js
+++ b/lib/mp-compiler/parse.js
@@ -70,6 +70,7 @@ const traverseComponentsVisitor = {
       const k = p.key.name || p.key.value
       const v = p.value.name || p.value.value
 
+      // 保留组件引用路径及模块名
       components[k] = {
         src: importsMap[v],
         module: v

--- a/lib/mp-compiler/util.js
+++ b/lib/mp-compiler/util.js
@@ -136,6 +136,21 @@ function getImportsMap (metadata) {
   return metadata
 }
 
+function getExportsMap (metadata) {
+  let { exportsMap } = metadata
+  const { exports } = metadata.modules
+
+  if (!exportsMap) {
+    exportsMap = {}
+    exports.specifiers.forEach(m => {
+      exportsMap[m.exported] = m.local
+    })
+    metadata.exportsMap = exportsMap
+  }
+
+  return metadata
+}
+
 const defaultStylePart = {
   type: 'style',
   content: '\n',
@@ -164,5 +179,6 @@ module.exports = {
   getBabelrc,
   getPathPrefix,
   getPageSrc,
-  getImportsMap
+  getImportsMap,
+  getExportsMap
 }

--- a/lib/mp-compiler/util.js
+++ b/lib/mp-compiler/util.js
@@ -119,6 +119,23 @@ function getPathPrefix (src) {
   return `${'../'.repeat(length)}`
 }
 
+function getImportsMap (metadata) {
+  let { importsMap } = metadata
+  const { imports } = metadata.modules
+
+  if (!importsMap) {
+    importsMap = {}
+    imports.forEach(m => {
+      m.specifiers.forEach(v => {
+        importsMap[v.local] = m.source
+      })
+    })
+    metadata.importsMap = importsMap
+  }
+
+  return metadata
+}
+
 const defaultStylePart = {
   type: 'style',
   content: '\n',
@@ -146,5 +163,6 @@ module.exports = {
   htmlBeautify,
   getBabelrc,
   getPathPrefix,
-  getPageSrc
+  getPageSrc,
+  getImportsMap
 }


### PR DESCRIPTION
初步实现了通过 `js` 文件间接引用 `vue` 组件，可能需要进一步测试，目前应该要求 `js` 文件和 `vue` 文件位于同一目录中才行

``` js
import newsItem from './news-item'
import topicItem from './topic-item'

export {
  newsItem,
  topicItem
}
```

``` js
import { newsItem } from '@/components'

export default {
  components: {
    newsItem
  }
}
```