### PR TITLE
##new feature: 小程序分包支持

### DIFF
--- a/lib/mp-compiler/index.js
+++ b/lib/mp-compiler/index.js
@@ -217,7 +217,9 @@ function compileMP (content, mpOptioins) {
           pages.splice(startPageIndex, 1)
           pages.unshift(startPage)
         }
-        configObj.pages = [...new Set(pages)]
+        if (mpOptioins.mergePages) {
+          configObj.pages = [...new Set(pages)]
+        }
       }
       emitFile(`${src}.json`, JSON.stringify(configObj, null, '  '))
     }


### PR DESCRIPTION
对mpvue-loader添加配置mergePages: false，使得mpvue-loader跳过对pages的默认处理，在main.js中指定分包的配置。
```
    pages: ['pages/index/main', 'pages/counter/main', 'pages/logs/main'],
    subPackages: [
      {
        root: 'testpkg',
        pages: ['pages/webview/index']
      }
    ],
mergePages: false设置后不能使用^代表小程序主页