### PR TITLE
修复style中对page标签添加scoped-id的bug

### DIFF
--- a/lib/style-compiler/plugins/scope-id.js
+++ b/lib/style-compiler/plugins/scope-id.js
@@ -42,9 +42,12 @@ module.exports = postcss.plugin('add-id', function (opts) {
             }
           })
 
-          selector.insertAfter(node, selectorParser.className({
-            value: opts.id
-          }))
+          // exclude page tag
+          if (node && node.value !== 'page') {
+            selector.insertAfter(node, selectorParser.className({
+              value: opts.id
+            }))
+          }
           // TODO, options for mp
           // selector.insertAfter(node, selectorParser.attribute({
           //   attribute: opts.id


### PR DESCRIPTION

```html
<style scoped>
page {
  background: #f0f0f0;
}
</style>
```

编译后

```css
page {
  background: #f0f0f0;
}
```