### PR TITLE
搭配mpvue-page-factory 可解决 mpvue issue 140

### DIFF
--- a/lib/mp-compiler/parse.js
+++ b/lib/mp-compiler/parse.js
@@ -43,6 +43,26 @@ const configVisitor = {
     path.traverse(traverseConfigVisitor)
     path.remove()
   },
+  
+  CallExpression: function (path) {
+    const {
+      metadata
+    } = path.hub.file
+    const {
+      importsMap
+    } = getImportsMap(metadata)
+    const calleeName = path.node.callee.name
+    if (calleeName !== 'Page') return;
+    const pageArg = path.node.arguments[0];
+    if (!pageArg || pageArg.type !== 'CallExpression') {
+      return
+    }
+    const arg = pageArg.arguments[0];
+    if (!arg) return;
+    const v = arg.type === 'Identifier' ? importsMap[arg.name] : importsMap['App']
+    metadata.rootComponent = v;
+  },
+
   NewExpression: function (path) {
     const { metadata } = path.hub.file
     const { importsMap } = getImportsMap(metadata)


### PR DESCRIPTION
搭配[mpvue-page-factory](https://github.com/HelloZJW/mpvue-page-factory) 可解决 [mpvue issue 140](https://github.com/Meituan-Dianping/mpvue/issues/140)

在页面的main.js中代替 app.$mount()

 ```javascript
import pageFactory from 'mpvue-page-factory'
import App from './index'

Page(pageFactory(App))
```