### PR TITLE
support monorepo

### DIFF
--- a/lib/mp-compiler/util.js
+++ b/lib/mp-compiler/util.js
@@ -16,7 +16,9 @@ function getFileInfo (resourcePath) {
 var hash = require('hash-sum')
 const cache = Object.create(null)
 function getCompNameAndSrc (context, file) {
-  const filePath = `/${resolveSrc(context, file)}.wxml`
+  let filePath = `/${resolveSrc(context, file)}.wxml`
+  // 支持monorepo
+  filePath = filePath.replace('/..', '')
   if (!cache[file]) {
     cache[file] = hash(file)
   }


### PR DESCRIPTION
 支持monorepo（yarn workspace or learn）。
如果`yarn workspace`有 3个package A，B，C。 A和B两个独立的需要构建的`mpvue`小程序，C是公用的组件

那么构建小程序A的时候
mpvue-loader会把`C`里的组件，build到 `A/C/`目录，而不是`A/dist/`里面，引用的时候则是通过
`<import src="/../C/shared-component.wxml"`的方式，但是C都不在dist里，造成引用错误。

需要把`C`构建到`A/dist`下面，修改同时修改掉path.