### PR TITLE
mpvue-loader 3.0

### DIFF
--- a/lib/mp-compiler/index.js
+++ b/lib/mp-compiler/index.js
@@ -4,7 +4,7 @@ const fs = require('fs')
 const deepEqual = require('deep-equal')
 const compiler = require('mpvue-template-compiler')
 
-const { parseConfig, parseComponentsDeps, parseGlobalComponents, clearGlobalComponents } = require('./parse')
+const { parseConfig, parseComponentsDeps, parseGlobalComponents, clearGlobalComponents, createMPParser } = require('./parse')
 const { parseComponentsDeps: parseComponentsDepsTs } = require('./parse-ts')
 const { genPageML } = require('./templates')
 
@@ -151,11 +151,15 @@ function compileMP (content, mpOptioins) {
 
   const babelrc = getBabelrc(mpOptioins.globalBabelrc)
   // app入口进行全局component解析
-  const { metadata } = babel.transform(content, { extends: babelrc, plugins: isApp ? [parseConfig, parseGlobalComponents] : [parseConfig] })
-
+  const { metadata, code } = babel.transform(content, { extends: babelrc, plugins: isApp ? [parseConfig, createMPParser, parseGlobalComponents] : [parseConfig, createMPParser] })
+  if (code) {
+    content = code
+  }
+  if (!metadata.globalComponents) {
+    metadata.globalComponents = {}
+  }
   // metadata: config
   const { rootComponent, globalComponents: globalComps } = metadata
-
   if (isApp) {
     // 保存旧数据，用于对比
     const oldGlobalComponents = globalComponents

--- a/lib/mp-compiler/parse.js
+++ b/lib/mp-compiler/parse.js
@@ -2,6 +2,7 @@
 
 const generate = require('babel-generator').default
 const babelon = require('babelon')
+const t = require('babel-types')
 
 function getImportsMap (metadata) {
   let { importsMap } = metadata
@@ -59,13 +60,84 @@ const configVisitor = {
     if (!arg) {
       return
     }
-
     const v = arg.type === 'Identifier' ? importsMap[arg.name] : importsMap['App']
     metadata.rootComponent = v || importsMap['index'] || importsMap['main']
   }
 }
 function parseConfig (babel) {
   return { visitor: configVisitor }
+}
+
+function createMPParser () {
+  return {
+    visitor: {
+      ImportDeclaration: function (path) {
+        if (path.node.specifiers && path.node.source && path.node.source.value === 'vue') {
+          const specifiersValue = path.node.specifiers[0].local.name
+          path.node.specifiers = [
+            t.importSpecifier(t.identifier(specifiersValue), t.identifier(specifiersValue)),
+            t.importSpecifier(t.identifier('createMP'), t.identifier('createMP'))
+          ]
+        }
+      },
+      VariableDeclaration: function (path) {
+        if (path.node.declarations &&
+          t.isVariableDeclarator(path.node.declarations[0]) &&
+          t.isNewExpression(path.node.declarations[0].init) &&
+          t.isIdentifier(path.node.declarations[0].init.callee, { name: 'Vue' })
+        ) {
+          const fnExpression = t.functionExpression(
+            null,
+            [],
+            t.blockStatement(
+              [
+                t.returnStatement(
+                  t.newExpression(
+                    path.node.declarations[0].init.callee,
+                    path.node.declarations[0].init.arguments
+                  )
+                )
+              ]
+            )
+          )
+          // 构造createMP的options
+          const objExpression = t.objectExpression(
+            [
+              t.objectProperty(
+                t.identifier('mpType'),
+                t.MemberExpression(
+                  t.identifier(path.node.declarations[0].init.arguments[0].name),
+                  t.identifier('mpType')
+                )
+              ),
+              t.objectProperty(
+                t.identifier('init'),
+                fnExpression
+              )
+            ]
+          )
+          path.replaceWith(t.expressionStatement(
+            t.callExpression(
+              t.identifier('createMP'),
+              [
+                objExpression
+              ]
+            )
+          ))
+        }
+      },
+      ExpressionStatement: function (path) {
+        if (
+          path.parentPath.node.type === 'Program' &&
+          path.node.expression.callee &&
+          path.node.expression.callee.property &&
+          path.node.expression.callee.property.name === '$mount'
+        ) {
+          path.remove()
+        }
+      }
+    }
+  }
 }
 
 // 解析 components
@@ -133,4 +205,4 @@ function parseGlobalComponents (babel) {
 function clearGlobalComponents () {
   globalComponents = {}
 }
-module.exports = { parseConfig, parseComponentsDeps, parseGlobalComponents, clearGlobalComponents }
+module.exports = { parseConfig, parseComponentsDeps, parseGlobalComponents, clearGlobalComponents, createMPParser }

--- a/lib/mp-compiler/parse.js
+++ b/lib/mp-compiler/parse.js
@@ -81,7 +81,7 @@ function createMPParser () {
           ]
         }
       },
-      // 处理const app = new Vue
+      // 处理const app = new Vue(App)
       // 构造为 createMp({
       //    mpType: App.mpType,
       //    init(){

--- a/lib/mp-compiler/parse.js
+++ b/lib/mp-compiler/parse.js
@@ -71,6 +71,7 @@ function parseConfig (babel) {
 function createMPParser () {
   return {
     visitor: {
+      // 将import Vue from 'vue' 替换为 import {Vue, createMP} from 'vue'
       ImportDeclaration: function (path) {
         if (path.node.specifiers && path.node.source && path.node.source.value === 'vue') {
           const specifiersValue = path.node.specifiers[0].local.name
@@ -80,6 +81,13 @@ function createMPParser () {
           ]
         }
       },
+      // 处理const app = new Vue
+      // 构造为 createMp({
+      //    mpType: App.mpType,
+      //    init(){
+      //       return new Vue(App)
+      //    }
+      // })
       VariableDeclaration: function (path) {
         if (path.node.declarations &&
           t.isVariableDeclarator(path.node.declarations[0]) &&
@@ -126,6 +134,7 @@ function createMPParser () {
           ))
         }
       },
+      // main.js中app.$mount()移除掉
       ExpressionStatement: function (path) {
         if (
           path.parentPath.node.type === 'Program' &&

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "babel-core": "^6.25.0",
     "babel-loader": "^7.0.0",
     "babel-preset-env": "^1.6.0",
+    "babel-types": "^6.26.0",
     "chai": "^4.1.0",
     "coffee-loader": "^0.7.2",
     "coffee-script": "^1.12.6",


### PR DESCRIPTION
- 处理main.js中Vue实例挂载，保留现有的开发习惯，在编译过程中，对入口进行替换